### PR TITLE
fix: typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can also configure various parts of the process using these optional flags.
 - `--duration` || `-d`: amount of seconds to run the prediction for (30s -> 18000s/30m). Default: `60`
 - `--success` || `-s`: string for success option (max 25 chars). Default: "Yes"
 - `--failure` || `-f`: string for failure option (max 25 chars) Default: "No"
-- `--token` || `-t`: __NOT RECOMMENDED__ Your Twitch API token. You can pass this flag if you want to avoid the OAuth flow. This flag is not recommended to be set live on screen, but if you want to store it in a config file for future use.
+- `--token` || `-k`: __NOT RECOMMENDED__ Your Twitch API token. You can pass this flag if you want to avoid the OAuth flow. This flag is not recommended to be set live on screen, but if you want to store it in a config file for future use.
 - `--port` || `-p`: The port for the local server for Twitch authentication.
   Must be one of `3000`, `4242`, `6969`, `8000`, `8008`, `8080`, or `42069`. Default: `3000`
 - `--config` || `-c`: path to config file for persistent configuration of flags: Default: `~/.config/.will-it-blend.yaml`


### PR DESCRIPTION
looks like `-t` is for title and `-k` is for token

https://github.com/cmgriffing/will-it-blend/blob/120b78b93bbcdc645fec9c0379dbd40707e4ec01/cmd/root.go#L105